### PR TITLE
Add 403 handling to a URL path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+**Jan.22.2025-1:** Now supporting multiple employees to have access. Found an issue where a 404 was provided instead of the correct HTTP 403.
+
 **Jan.21.2025-1:** Initial email now sends an HTML template including TKT_ID, Status, and the user provided notes as a reminder.
 
 **Jan.20.2025-3:** locally stored GoobyFRS Branding, removing dependancy on my personal Object Storage. Disabing Debug mode out of the box for a leaner runtime.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Simple, Lightweight, Databaseless Service Desk for Home Labbers, Families, and One Man MSPs.
 
-**Current Version:**  v0.1.10
+**Current Version:**  v0.1.11
 
 ## How GoobyDesk works
 
@@ -36,7 +36,6 @@ CTRL+C to break. ```deactivate``` to clean up.
 ### Goals and Roadmap
 
 - Ability to set In-Progress status.
-- OAuth2.0 Support for Email Authentication.
 - Fine tune email reply handling.
 - HTML Form validation.
 - File locking and retry support.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -139,7 +139,7 @@
                 alert("Ticket Number was NOT found. Try again.");
                 return;
             }
-        
+                    
             fetch('/close_ticket/' + ticketId, {
                 method: 'POST'
             })


### PR DESCRIPTION
If a user attempted to navigate to /ticket/TKT-Number it would prompt a 404.

Ideally this should be a 403. This MR adds in a 403 on the clients cookie for these paths.

Next feature will likely be the in-progress button