### PR TITLE
v0.4.1-beta merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ Closed Tickets are hidden from the Dashboard by default.
 
 ## Goals and Roadmap to Production v1.0
 
-- Implement "Logged In Technician" and Closed_By status.
+- Implement "Logged In Technician" to HTML templates.
+- Implement Closure timestamp.
+- Implement Closed By value.
+- Implement Technician-posted notes.
 - Implement standardized ```/var/log/goobydesk``` logging.
 
 ### Linux Project Setup

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Closed Tickets are hidden from the Dashboard by default.
 
 ## Goals and Roadmap to Production v1.0
 
-- Implement "Logged In Technician" to HTML templates.
-- Implement Closed_timestamp.
-- Implement ClosedBy value.
-- Implement Technician-posted notes.
-- Implement standardized ```/var/log/goobydesk``` logging.
+- Implement "Logged In Technician" to HTML templates. (Pending)
+- Implement Closed_timestamp. (Pending)
+- Implement ClosedBy value. (Pending)
+- Implement Technician-posted notes. (Not Started)
+- Implement standardized ```/var/log/goobydesk``` logging. (Not Started)
 
 ### Linux Project Setup
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ CTRL+C to break. ```deactivate``` to clean up.
 
 **Technically Broken, no longer supported.**
 
-1. Comment out ```import fcntl```
+1. Comment out ```import fcntl``` line 11.
 2. Comment out ```load_tickets``` lines 44-60.
 3. Uncomment top ```load_tickets```. lines 35 - 42.
 4. Enable Debugging at EOF.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Closed Tickets are hidden from the Dashboard by default.
 ## Goals and Roadmap to Production v1.0
 
 - Implement "Logged In Technician" to HTML templates.
-- Implement Closure timestamp.
-- Implement Closed By value.
+- Implement Closed_timestamp.
+- Implement ClosedBy value.
 - Implement Technician-posted notes.
 - Implement standardized ```/var/log/goobydesk``` logging.
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Closed Tickets are hidden from the Dashboard by default.
 
 ## Goals and Roadmap to Production v1.0
 
-- Implement "Logged In Technician" for Closed_By status.
-- File locking and retry support on Windows. (CONSIDERING DROPPING)
+- Implement "Logged In Technician" and Closed_By status.
 - Implement standardized ```/var/log/goobydesk``` logging.
 
 ### Linux Project Setup
@@ -71,7 +70,8 @@ CTRL+C to break. ```deactivate``` to clean up.
 
 1. Comment out ```import fcntl```
 2. Comment out ```load_tickets``` lines 44-60.
-3. Uncomment top ```load_tickets```.
+3. Uncomment top ```load_tickets```. lines 35 - 42.
+4. Enable Debugging at EOF.
 
 ```shell
 python -m venv venv

--- a/README.md
+++ b/README.md
@@ -2,42 +2,51 @@
 
 Simple, Lightweight, Databaseless Service Desk for Home Labbers, Families, and One Man MSPs.
 
-**Current Version:**  v0.4.0
+**Current Version:**  v0.4.1
 
 [GoobyDesk Repo Wiki](https://github.com/GoobyFRS/GoobyDesk/wiki) & [Production Deployment Guide](https://github.com/GoobyFRS/GoobyDesk/wiki/Production-Deployment-Guide) you can find information on my code standards, my variables, and other data I think is important for an open source project to be successful after the creator moves on.
 
 ## What is GoobyDesk
 
-- GoobyDesk is a Python3, Flask-based web application.
-  - By default, the Flask app will run at ```http://127.0.0.1:5000``` during local development.
-  - Production instances should be ran behind a Python3 WSGI server such as [Gunicorn](https://gunicorn.org/).
-  - Production Gunicorn instances should be ran behind a Reverse Proxy such as [Caddy](https://caddyserver.com/).
-- Mobile-friendly landing page with lightweight ticket submission.
-  - Requestor Name
-  - Requestor Contact Email
-  - Ticket Subject/Title
-  - Ticket Impact
-    - Low
-    - Medium
-    - High
-  - Ticket Urgency
-    - Planning
-    - Low
-    - Medium
-    - High
-  - Ticket Message
-  - Ticket Category
-    - Request
-    - Incident
-    - Maintenance
-    - Change
-    - Access
-- New Ticket Created confirmation emails are sent from an inbox defined in a DOTENV file.
-- New Ticket Created confirmation emails are based on a clean HTML5 Jinja template that can be easily customized.
-- User email replies are appended to the ticket notes.
-- Technician Dashboard where logged in users can view Open Tickets and Close them.
-  - Support for multiple technicians.
-  - Closed Tickets are hidden by default.
+GoobyDesk is a Python3, Flask-based web application.
+
+- By default, the Flask app will run at ```http://127.0.0.1:5000``` during local development.
+- Production instances should be ran behind a Python3 WSGI server such as [Gunicorn](https://gunicorn.org/).
+- Production Gunicorn instances should be ran behind a Reverse Proxy such as [Caddy](https://caddyserver.com/).
+
+Mobile-friendly landing page with lightweight ticket submission.
+
+- Requestor Name
+- Requestor Contact Email
+- Ticket Subject/Title
+- Ticket Impact
+  - Low
+  - Medium
+  - High
+- Ticket Urgency
+  - Planning
+  - Low
+  - Medium
+  - High
+- Ticket Message
+- Ticket Category
+  - Request
+  - Incident
+  - Maintenance
+  - Change
+  - Access
+
+New Ticket Created confirmation emails are sent from an inbox defined in a DOTENV file.
+
+New Ticket Created confirmation emails are based on a clean HTML5 Jinja template that can be easily customized.
+
+User email replies are appended to the ticket notes.
+
+Technician Dashboard where logged in users can view Open Tickets and manage them.
+
+Support for multiple technicians.
+
+Closed Tickets are hidden from the Dashboard by default.
 
 ## Goals and Roadmap to Production v1.0
 

--- a/app.py
+++ b/app.py
@@ -301,24 +301,6 @@ def update_ticket_status(ticket_number, ticket_status):
         
     return render_template("404.html"), 404
 
-# Route/routine to close a ticket. Originally implemented on the dashboard but now is legacy code.
-# This API/POST route will be removed pre v1.0.0
-#@app.route("/close_ticket/<ticket_number>", methods=["POST"])
-#def close_ticket(ticket_number):
-#    if not session.get("technician"):  # Check the cookie for technician tag.
-#        return render_template("403.html"), 403
-#    
-#    tickets = load_tickets()
-#    for ticket in tickets:
-#        if ticket["ticket_number"] == ticket_number: # Basic input validation.
-#            ticket["ticket_status"] = "Closed"
-#            save_tickets(tickets)
-#            send_TktUpdate_discord_notification(ticket_number) # Discord notification for closing a ticket.
-#            return jsonify({"message": f"Ticket {ticket_number} has been closed."}) # Browser Popup to confirm ticket closure.
-#        
-#    # If the ticket was not found....
-#    return render_template("404.html"), 404
-
 # Removes the session cookie from the user browser, sending the Technician/user back to the login page.
 @app.route("/logout")
 def logout():

--- a/app.py
+++ b/app.py
@@ -299,7 +299,7 @@ def update_ticket_status(ticket_number, ticket_status):
             ticket["ticket_status"] = ticket_status  
 
             if ticket_status == "Closed":
-                ticket["ClosedBy"] = loggedInTech  # Append the Closed_By_Tech to support ticket audits.
+                ticket["closed_by"] = loggedInTech  # Append the Closed_By_Tech to support ticket audits.
                 ticket["closure_date"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")  # Append the ticket closure date.
 
             save_tickets(tickets)  # Save the updated tickets.

--- a/app.py
+++ b/app.py
@@ -237,7 +237,7 @@ def home():
     
     return render_template("index.html")
 
-# Route/routine for the technician login process.
+# Route/routine for the technician login page/process.
 @app.route("/login", methods=["GET", "POST"])
 def login():
     if request.method == "POST":
@@ -256,18 +256,18 @@ def login():
         
     return render_template("login.html")
 
-# Route/routine for the technician login process.
+# Route/routine for rendering the core technician dashboard. Displays all Open and In-Progress tickets.
 @app.route("/dashboard")
 def dashboard():
-    if not session.get("technician"): # If the local machine does not have a session token/cookie containing the 'technician' tag.
-        return redirect(url_for("login")) # Redirect them to the login page.
+    if not session.get("technician"): # Check for technician login cookie.
+        return redirect(url_for("login")) #else redirect them to the login page.
     
     tickets = load_tickets()
     # Filtering out tickets with the Closed Status on the main Dashboard.
     open_tickets = [ticket for ticket in tickets if ticket["ticket_status"].lower() != "closed"]
     return render_template("dashboard.html", tickets=open_tickets)
 
-# Route/routine for viewing a ticket, loads into what I call Ticket Commander.
+# Route/routine for viewing a ticket in the Ticket Commander view.
 @app.route("/ticket/<ticket_number>")
 def ticket_detail(ticket_number):
     if "technician" not in session:  # Validate the logged-in user cookie...
@@ -281,7 +281,7 @@ def ticket_detail(ticket_number):
 
     return render_template("404.html"), 404
 
-# Route/routine for updating a ticket from Ticket Commander.
+# Route/routine for updating a ticket. Called from Dashboard and Ticket Commander.
 @app.route("/ticket/<ticket_number>/update_status/<ticket_status>", methods=["POST"])
 def update_ticket_status(ticket_number, ticket_status):
     if not session.get("technician"):  # Ensure only authenticated techs can update tickets.

--- a/example-tickets.json
+++ b/example-tickets.json
@@ -7,7 +7,7 @@
         "ticket_message": "Can you help me with my computer issue?",
         "request_type": "Request",
         "ticket_impact": "Low Impact",
-        "ticket_urgency": "Panning",
+        "ticket_urgency": "Planning",
         "ticket_status": "Open",
         "submission_date": "2025-02-08 08:51:40",
         "ticket_notes": [] 

--- a/local_webhook_handler.py
+++ b/local_webhook_handler.py
@@ -68,7 +68,7 @@ def send_TktUpdate_discord_notification(ticket_number, ticket_status):
         response.raise_for_status()  # Raise exception for HTTP errors
         
         if response.status_code == 204:
-            print(f"INFO - WEBHOOK HANDLER - Ticket {ticket_number} has been closed notification sent to Discord.")
+            print(f"INFO - WEBHOOK HANDLER - Ticket {ticket_number} status change notification sent to Discord.")
         else:
             print(f"WARNING - WEBHOOK HANDLER - Unexpected response code: {response.status_code}")
 

--- a/local_webhook_handler.py
+++ b/local_webhook_handler.py
@@ -44,8 +44,8 @@ def send_discord_notification(ticket_number, ticket_message):
     except requests.exceptions.RequestException as e:
         print(f"ERROR - WEBHOOK HANDLER - Unexpected error: {e}")
 
-# Uncalled function for TktClosed notifications to be added into a TicketCommander workflow.
-def send_TktClosed_discord_notification(ticket_number, ticket_status):
+# send_TktUpdate_discord_notification will send a webhook when the status becomes In-Progress or Closed..
+def send_TktUpdate_discord_notification(ticket_number, ticket_status):
     if not DISCORD_WEBHOOK_URL:
         print("ERROR - WEBHOOK HANDLER - DISCORD_WEBHOOK_URL is not set. Check your .env file.")
         return

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -166,7 +166,8 @@
         
         <!-- Technician logout button -->
         <a href="{{ url_for('logout') }}" class="logout-btn">Logout</a>
-        <p class="footer-text">©2025 GoobyDesk, FOSS by <a href="https://www.bluebotpc.com/">BlueBotPC</a></p>
+        <!-- Footer Text -->
+        <p class="footer-text">©2025 GoobyDesk, FOSS by <a href="https://www.bluebotpc.com/">BlueBotPC</a> | Logged In as: {{ loggedInTech }}</p>
     </div>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -152,7 +152,7 @@
 
             <label for="ticket_urgency">Ticket Urgency:</label>
             <select id="type" name="ticket_urgency" required>
-                <option value="Panning">Planning</option>
+                <option value="Planning">Planning</option>
                 <option value="Low Urgency">Low</option>
                 <option value="Medium Urgency">Medium</option>
                 <option value="High Urgency">High</option>

--- a/templates/ticket-commander.html
+++ b/templates/ticket-commander.html
@@ -133,7 +133,7 @@
                 .catch(error => console.error("Error:", error));
             }
         </script>
-        <p class="footer-text">©2025 GoobyDesk, FOSS by <a href="https://www.bluebotpc.com/">BlueBotPC</a></p>
+        <p class="footer-text">©2025 GoobyDesk, FOSS by <a href="https://www.bluebotpc.com/">BlueBotPC</a> | Logged In as: {{ loggedInTech }}</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Dashboard and Ticket Commander pages now show the logged in technician in the footer.

closed_by technician is now logged to the ticket to support tech audits

closure_date is now logged to the ticket to support sla audits

Local webhook handler had minor changes to improve code readability. 
Example, send_TktUpdate_discord_notification was previously send_TktClosed_discord_notification. However the function was called more than just when a ticket is closed.

Fixed a spelling error in the JSON template. Panning is now "Planning"