### PR TITLE
Logo and Email template fixes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,12 +12,12 @@
     <!-- Social Media Preview -->
     <meta property="og:title" content="GoobyDesk - Submit a Ticket">
     <meta property="og:description" content="GoobyDesk, a Databaseless Service Desk for SMBs.">
-    <meta property="og:image" content="https://mattfaulkner.us-southeast-1.linodeobjects.com/GoobyDesk-color.webp">
-    <meta property="og:url" content="https://support.bluebotpc.com/">
+    <meta property="og:image" content="https://raw.githubusercontent.com/GoobyFRS/GoobyDesk/refs/heads/main/static/GoobyDesk-color.webp">
+    <meta property="og:url" content="https://support.mattfaulkner.net/">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="GoobyDesk - Submit a Ticket">
     <meta name="twitter:description" content="GoobyDesk, a Databaseless Service Desk for SMBs.">
-    <meta name="twitter:image" content="https://mattfaulkner.us-southeast-1.linodeobjects.com/GoobyDesk-color.webp">
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/GoobyFRS/GoobyDesk/refs/heads/main/static/GoobyDesk-color.webp">
 
     <!-- Performance Enhancements -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -147,7 +147,7 @@
 <body>
     <div class="container">
         <div class="logo">
-            <img src="https://github.com/GoobyFRS/GoobyDesk/blob/main/static/GoobyDesk-color.webp" alt="GoobyDesk Logo">
+            <img src="https://raw.githubusercontent.com/GoobyFRS/GoobyDesk/refs/heads/main/static/GoobyDesk-color.webp" alt="GoobyDesk Logo">
         </div>
         <h2>Submit a Ticket</h2>
         <form method="post">
@@ -200,7 +200,7 @@
             {% endfor %}
           {% endif %}
         {% endwith %}
-        <p class="footer-text">©2025 GoobyDesk, FOSS created by <a href="https://github.com/bluebotpc">Gooby</a> | <a href="{{ url_for('login') }}">Tech Login</a></p>
+        <p class="footer-text">©2025 GoobyDesk, FOSS created by <a href="https://github.com/GoobyFRS">GoobyFRS</a> | <a href="{{ url_for('login') }}">Tech Login</a></p>
     </div>
 </body>
 </html>

--- a/templates/new-ticket-email.html
+++ b/templates/new-ticket-email.html
@@ -98,13 +98,13 @@
         <table role="presentation" border="0" cellspacing="0" cellpadding="0">
           <tr>
             <td>
-              <a target="_blank" href="https://github.com/bluebotpc" rel="noopener noreferrer">github</a> |
-              <a target="_blank" href="https://discord.gg/ge6necsyxR" rel="noopener noreferrer">Discord</a> |
+              <a target="_blank" href="https://github.com/GoobyFRS" rel="noopener noreferrer">Github</a> |
+              <a target="_blank" href="https://discord.gg/ge6necsyxR" rel="noopener noreferrer">Goobys Discord</a> |
               <p class="footer-text">
                 This was an automated message sent by the GoobyDesk Service Desk. If you are not the intended recipient, please let us know and we will ensure you are not contacted by our system again. 
               </p>
               <p class="footer-text" style="margin-bottom: 50px;">
-              ©2025 GoobyDesk, FOSS created by <a href="https://github.com/bluebotpc">Gooby</a>
+              ©2025 GoobyDesk, FOSS created by <a href="https://github.com/GoobyFRS">GoobyFRS</a>
             </p>
             </td>
           </tr>


### PR DESCRIPTION
Noticed some inconsistent HTML pointing to the old BlueBotPC branding that I no longer use for this project.
That has been removed.

GoobyDesk logo pointed to the GitHub raw file in the "main" repo making it actually load since I got rid of my personal S3 bucket